### PR TITLE
Add --no-antialiased Option to 3DGS Application for Non-MIP Splatting Texturing

### DIFF
--- a/synctweedies/config/gs_config.py
+++ b/synctweedies/config/gs_config.py
@@ -39,8 +39,9 @@ def load_gs_config():
     parser.add_argument("--plyfile", type=str, default=None)
     parser.add_argument('--source_path', type=str, default=None, required=False, help="source_path must be provided for colmap and blender dataset")
     parser.add_argument("--up_vec", type=str, default="z", choices=["z", "y"])
-    parser.add_argument("--antialiased", action="store_true", default=True)
-
+    parser.add_argument('--antialiased', action='store_true')
+    parser.add_argument('--no-antialiased', dest='antialiased', action='store_false')
+    parser.set_defaults(antialiased=True)
     parser.add_argument("--zt_init", action="store_true", default=False)
     parser.add_argument("--background_color", type=str, default="white", choices=["white", "black"])
     parser.add_argument("--color_assign_method", type=str, default="previous", choices=["zero", "previous", "instance"])

--- a/test/run_3dgs.py
+++ b/test/run_3dgs.py
@@ -11,7 +11,8 @@ command = f'python main.py \
     --dataset_type blender \
     --case_num 2 \
     --zt_init \
-    --force_clean_composition'
+    --force_clean_composition \
+    --no-antialiased'
     
 subprocess.call(command, shell=True)
 print("Done")


### PR DESCRIPTION
Introduced a new --no-antialiased option to the 3DGS configuration. When this option is enabled, MIP-splatting is not used. (suitable for texturing of PLY files from the original 3DGS training)